### PR TITLE
Order portal after graphical-session.target

### DIFF
--- a/data/plasma-xdg-desktop-portal-kde.service.in
+++ b/data/plasma-xdg-desktop-portal-kde.service.in
@@ -1,7 +1,7 @@
 [Unit]
 Description=Xdg Desktop Portal For KDE
 PartOf=graphical-session.target
-After=plasma-core.target
+After=plasma-core.target graphical-session.target
 
 [Service]
 ExecStart=@CMAKE_INSTALL_FULL_LIBEXECDIR@/xdg-desktop-portal-kde


### PR DESCRIPTION
Otherwise portal unit might try to start before compositor exported `WAYLAND_DISPLAY` to activation environments.
[Reference](https://github.com/Vladimir-csp/uwsm/issues/37#issuecomment-2307818022)