### PR TITLE
Fix handling of current folder path in file chooser

### DIFF
--- a/src/filechooser.cpp
+++ b/src/filechooser.cpp
@@ -363,9 +363,14 @@ void FileChooserPortal::OpenFile(const QDBusObjectPath &handle,
 
     if (options.contains(QStringLiteral("current_folder"))) {
         currentFolder = decodeFileName(options.value(QStringLiteral("current_folder")).toByteArray());
+
         if (QDir::isRelativePath(currentFolder)) {
             qCInfo(XdgDesktopPortalKdeFileChooser) << "ignoring non absolute path" << currentFolder;
             currentFolder.clear();
+        }
+
+        if (!currentFolder.isEmpty() && !currentFolder.endsWith(QLatin1Char('/'))) {
+            currentFolder += QLatin1Char('/');
         }
     }
 
@@ -542,9 +547,14 @@ void FileChooserPortal::SaveFile(const QDBusObjectPath &handle,
 
     if (options.contains(QStringLiteral("current_folder"))) {
         currentFolder = decodeFileName(options.value(QStringLiteral("current_folder")).toByteArray());
+
         if (QDir::isRelativePath(currentFolder)) {
             qCInfo(XdgDesktopPortalKdeFileChooser) << "ignoring non absolute path" << currentFolder;
             currentFolder.clear();
+        }
+
+        if (!currentFolder.isEmpty() && !currentFolder.endsWith(QLatin1Char('/'))) {
+            currentFolder += QLatin1Char('/');
         }
     }
 


### PR DESCRIPTION
Without a trailing forward slash the parent folder of the specified directory is opened, instead of the correct folder.
Horribly inelegant, but I did test it and it works.

This is intended less as a serious patch and more to bring light to this bug and showcase a "work-around".
